### PR TITLE
Add FILE_DELIMITER for FilesBrowse and popup_get_files

### DIFF
--- a/TkEasyGUI/dialogs.py
+++ b/TkEasyGUI/dialogs.py
@@ -42,6 +42,8 @@ POPUP_AUTO_SCREENSHOT_FILENAME = "screenshot.png"
 POPUP_OK_BUTTON_WIDTH = 12
 POPUP_CANCEL_BUTTON_WIDTH = 9
 POPUP_TTK_BUTTONS = True  # use ttk buttons
+# delimiter for multiple files, used in popup_get_file with multiple_files=True
+POPUP_FILES_DELIMITER = "|" if is_win() else ";"
 
 
 def popup_set_options(
@@ -712,7 +714,9 @@ def popup_get_file(
     multiple_files: bool = False,  # can select multiple files
     file_types: Optional[FileTypeList] = None,
     default_extension: Optional[str] = None,
-    files_delimiter: Optional[str] = "|",
+    files_delimiter: Optional[
+        str
+    ] = POPUP_FILES_DELIMITER,  # delimiter for multiple files, used when multiple_files=True
     # pylint: disable=unused-argument
     no_window: Optional[bool] = None,  # for compatibility
     **kw,

--- a/TkEasyGUI/dialogs.py
+++ b/TkEasyGUI/dialogs.py
@@ -42,8 +42,6 @@ POPUP_AUTO_SCREENSHOT_FILENAME = "screenshot.png"
 POPUP_OK_BUTTON_WIDTH = 12
 POPUP_CANCEL_BUTTON_WIDTH = 9
 POPUP_TTK_BUTTONS = True  # use ttk buttons
-# delimiter for multiple files, used in popup_get_file with multiple_files=True
-POPUP_FILES_DELIMITER = "|" if is_win() else ";"
 
 
 def popup_set_options(
@@ -716,25 +714,27 @@ def popup_get_file(
     default_extension: Optional[str] = None,
     files_delimiter: Optional[
         str
-    ] = POPUP_FILES_DELIMITER,  # delimiter for multiple files, used when multiple_files=True
+    ] = None,  # default is FILES_DELIMITER for multiple files, used when multiple_files=True
     # pylint: disable=unused-argument
     no_window: Optional[bool] = None,  # for compatibility
     **kw,
-) -> Union[str, tuple[str], None]:
+) -> Optional[str]:
     """Popup a file selection dialog. Return the file selected."""
+    from . import widgets as eg
+
     if title is None:
         title = message
     if initial_folder is None:
         initial_folder = os.getcwd()
     if file_types is None:
         file_types = [("All Files", "*.*")]
+    if files_delimiter is None:
+        files_delimiter = eg.FILES_DELIMITER
     # check no_window
     if no_window is None:
         no_window = True
     if no_window is False:
         # --- no_window is False ---
-        from . import widgets as eg
-
         # show base dialog
         layout_no_window: list[list[eg.Element]] = [
             [eg.Text(message)],
@@ -785,8 +785,7 @@ def popup_get_file(
             **kw,
         )
     if multiple_files and isinstance(result, (tuple, list)):
-        if files_delimiter is not None:
-            result = files_delimiter.join(result)
+        result = str(files_delimiter).join(result)
     return result
 
 

--- a/TkEasyGUI/widgets.py
+++ b/TkEasyGUI/widgets.py
@@ -82,6 +82,10 @@ TABLE_SELECT_MODE_EXTENDED: str = tk.EXTENDED
 EG_SWAP_EVENT_NAME: str = "--swap_event_name--"
 
 DEFAULT_PADX = 1 if utils.is_win() else 3
+FILES_DELIMITER = (
+    "|" if utils.is_win() else ":"
+)  # delimiter for multiple files, used in popup_get_file with multiple_files=True
+
 
 # --- window icon ---
 DEFAULT_WINDOW_ICON = icon_default.ICON
@@ -93,10 +97,6 @@ SCREENSHOT_MACOS_ADJUST = {
     "x2": 0,
     "y2": 22 + 6,
 }  # for macOS titlebar
-
-# delimiter for multiple files, used in popup_get_file with multiple_files=True
-FILES_DELIMITER = "|" if utils.is_win() else ":"
-
 
 # ------------------------------------------------------------------------------
 # Widget wrapper
@@ -4755,7 +4755,7 @@ class FileBrowse(Element):
         init_dir = self._get_initial_directory()
 
         # popup
-        result = dialogs.popup_get_file(
+        popup_result = dialogs.popup_get_file(
             title=self.title,
             initial_folder=init_dir,
             save_as=self.save_as,
@@ -4763,18 +4763,7 @@ class FileBrowse(Element):
             multiple_files=self.multiple_files,
             files_delimiter=self.files_delimiter,
         )
-        target_value = result
-        if isinstance(target_value, (list, tuple)):
-            delimiter = self.files_delimiter
-            if delimiter is not None:
-                target_value = delimiter.join(str(item) for item in target_value)
-            else:
-                # Keep popup_get_file return value unchanged (tuple/list) while
-                # updating target widgets/events with a readable string.
-                fallback_delimiter = " "
-                target_value = fallback_delimiter.join(
-                    str(item) for item in target_value
-                )
+        target_value = popup_result if popup_result is not None else ""
         if (target is not None) and (target_value is not None) and (target_value != ""):
             target.update(target_value)  # type: ignore [call-arg]
             if self.enable_events:
@@ -4782,8 +4771,7 @@ class FileBrowse(Element):
                     self.window.dispatch_event(
                         self.key, {"event": target_value, "event_type": "change"}
                     )
-
-        return result
+        return popup_result
 
     def set_text(self, text: str) -> None:
         """Set the text of the button."""
@@ -4807,7 +4795,7 @@ class FilesBrowse(FileBrowse):
         target_key: Union[str, None] = None,
         title: str = "",
         file_types: Optional[FileTypeList] = None,
-        files_delimiter: Optional[str] = "|",
+        files_delimiter: Optional[str] = FILES_DELIMITER,
         enable_events: bool = False,  # enable changing events
         # other
         metadata: Union[dict[str, Any], None] = None,

--- a/TkEasyGUI/widgets.py
+++ b/TkEasyGUI/widgets.py
@@ -94,6 +94,9 @@ SCREENSHOT_MACOS_ADJUST = {
     "y2": 22 + 6,
 }  # for macOS titlebar
 
+# delimiter for multiple files, used in popup_get_file with multiple_files=True
+FILES_DELIMITER = "|" if utils.is_win() else ":"
+
 
 # ------------------------------------------------------------------------------
 # Widget wrapper
@@ -4688,7 +4691,7 @@ class FileBrowse(Element):
         save_as: bool = False,
         enable_events: bool = False,  # enable changing events
         # other
-        files_delimiter: Optional[str] = "|",
+        files_delimiter: Optional[str] = FILES_DELIMITER,
         metadata: Union[dict[str, Any], None] = None,
         **kw,
     ) -> None:
@@ -4769,7 +4772,9 @@ class FileBrowse(Element):
                 # Keep popup_get_file return value unchanged (tuple/list) while
                 # updating target widgets/events with a readable string.
                 fallback_delimiter = " "
-                target_value = fallback_delimiter.join(str(item) for item in target_value)
+                target_value = fallback_delimiter.join(
+                    str(item) for item in target_value
+                )
         if (target is not None) and (target_value is not None) and (target_value != ""):
             target.update(target_value)  # type: ignore [call-arg]
             if self.enable_events:

--- a/tests/filebrowse_test.py
+++ b/tests/filebrowse_test.py
@@ -29,7 +29,7 @@ while window.is_alive():
         print(values)
         a = [
             f"path1={values['-filepath1-']}",
-            f"path2={values["-filepath2-"]}",
+            f"path2={values['-filepath2-']}",
             f"folder={values['-folderpath-']}",
         ]
         eg.popup("Selected:\n" + "\n".join(a))

--- a/tests/filebrowse_test.py
+++ b/tests/filebrowse_test.py
@@ -5,8 +5,6 @@ FileBrowse test
 # import PySimpleGUI as sg
 import TkEasyGUI as eg
 
-FILES_DELIMITER = "|"
-
 # window create
 window = eg.Window(
     "FileBrowser test",
@@ -14,7 +12,10 @@ window = eg.Window(
         [eg.Text("File path:")],
         [eg.Input("", key="-filepath1-"), eg.FileBrowse()],
         [eg.Text("Multiple path:")],
-        [eg.Input("", key="-filepath2-"), eg.FilesBrowse(files_delimiter=FILES_DELIMITER)],
+        [
+            eg.Input("", key="-filepath2-"),
+            eg.FilesBrowse(files_delimiter=eg.FILES_DELIMITER),
+        ],
         [eg.Text("Folder path:")],
         [eg.Input("", key="-folderpath-"), eg.FolderBrowse()],
         [eg.Button("OK")],
@@ -26,14 +27,9 @@ while window.is_alive():
     print("#", event, values)
     if event == "OK":
         print(values)
-        selected_multiple = values["-filepath2-"]
-        selected_multiple_list = []
-        if selected_multiple not in ("", None):
-            selected_multiple_list = str(selected_multiple).split(FILES_DELIMITER)
         a = [
             f"path1={values['-filepath1-']}",
-            f"path2={selected_multiple}",
-            f"path2-list={selected_multiple_list}",
+            f"path2={values["-filepath2-"]}",
             f"folder={values['-folderpath-']}",
         ]
         eg.popup("Selected:\n" + "\n".join(a))

--- a/tests/popup/popup_get_file_sp_file_types.py
+++ b/tests/popup/popup_get_file_sp_file_types.py
@@ -4,20 +4,19 @@
 
 import TkEasyGUI as eg
 
-FILES_DELIMITER = "|"
-
 # file types
-file_types = (
+file_types = [
     ("Image files", "*.jpg;*.jpeg;*.jpe;*.heic;*.png;*.gif"),
     ("All files", "*.*"),
-)
+]
 # popup
-files = eg.popup_get_file(
+files_str = eg.popup_get_file(
     "Please select images.",
     file_types=file_types,
     multiple_files=True,
-    files_delimiter=FILES_DELIMITER,
+    files_delimiter=eg.FILES_DELIMITER,
 )
-print(f"raw={files}")
-if files not in (None, ""):
-    print(files.split(FILES_DELIMITER))
+print(f"Selected: {files_str}")
+if files_str:
+    files = files_str.split(eg.FILES_DELIMITER)
+    eg.popup_listbox(files, "Selected Files")

--- a/tests/popup/select_multiple_files.py
+++ b/tests/popup/select_multiple_files.py
@@ -2,13 +2,11 @@
 
 import TkEasyGUI as eg
 
-FILES_DELIMITER = "|"
-
 selected_files = eg.popup_get_file(
     "Please select files.",
     title="Select Multiple Files",
     multiple_files=True,
-    files_delimiter=FILES_DELIMITER,
+    files_delimiter=eg.FILES_DELIMITER,
 )
 
 if selected_files in (None, ""):
@@ -16,5 +14,7 @@ if selected_files in (None, ""):
 else:
     print(f"raw={selected_files}")
     print("split:")
-    for index, file_path in enumerate(str(selected_files).split(FILES_DELIMITER), start=1):
+    for index, file_path in enumerate(
+        str(selected_files).split(eg.FILES_DELIMITER), start=1
+    ):
         print(f"  {index}. {file_path}")


### PR DESCRIPTION
This pull request standardizes the way file delimiters are handled when selecting multiple files in the `popup_get_file` dialog, making the delimiter platform-dependent (using `|` on Windows and `:` on other systems). It also updates related tests and internal APIs to use this new approach. The most important changes are grouped below:

**Core functionality improvements:**

* Introduced a new `FILES_DELIMITER` constant in `widgets.py` that sets the default delimiter to `|` on Windows and `:` on other platforms, and updated the `files_delimiter` parameter in relevant functions to use this constant by default. [[1]](diffhunk://#diff-52a20bf597e2e35f354a748bf66fdee3d7300affabf2ec181ed738443da4e8baR97-R99) [[2]](diffhunk://#diff-52a20bf597e2e35f354a748bf66fdee3d7300affabf2ec181ed738443da4e8baL4691-R4694)
* Updated the `popup_get_file` function in `dialogs.py` to use `FILES_DELIMITER` as the default when `multiple_files=True`, and simplified its return type to always return a string or `None`.
* Changed the logic in `popup_get_file` to always join multiple selected files using the specified delimiter, ensuring consistent output.

**Test and usage updates:**

* Refactored test scripts (`popup_get_file_sp_file_types.py` and `select_multiple_files.py`) to use `eg.FILES_DELIMITER` instead of hardcoding delimiters, and improved how selected files are displayed and split. [[1]](diffhunk://#diff-d3e36f27da0e978ed7f650fd01fc65839674f193e84c878d84b35d0fb89e5b53L7-R22) [[2]](diffhunk://#diff-dcc8ee0fbae80657d22b4a131ec4331c8132120a5fb7a026327b81b0b17b3986L5-R19)

**Internal consistency:**

* Ensured that the fallback delimiter for display purposes inside `show_dialog` remains a space, but the actual value uses the platform-specific delimiter. FILE_DELIMITER for FilesBrowse and popup_get_files #148
